### PR TITLE
feat: set version of coderoad

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,6 @@
   "dockerFile": "../Dockerfile",
   "workspaceFolder": "/home/codeally/project",
   "extensions": [
-    "coderoad.coderoad"
+    "coderoad.coderoad@0.15.1"
   ]
 }


### PR DESCRIPTION
Issue: latest version of CodeRoad was auto loading the learn NPM tutorial from the tutorial selection drop down menu without all the files. Setting it to install an older version for now.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
